### PR TITLE
fix: Changer la couleur du titre en bleu

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@latest",
+        "--headless"
+      ]
+    }
+  }
+}

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -1,0 +1,17 @@
+# Override Docker Compose pour review via Traefik
+# Généré automatiquement par Hexapilot
+# Le hostname est injecté via la variable d'env REVIEW_HOST
+
+services:
+  app:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${REVIEW_HOST}`)"
+      - "traefik.http.services.${COMPOSE_PROJECT_NAME}.loadbalancer.server.port=80"
+    networks:
+      - default
+      - traefik_network
+
+networks:
+  traefik_network:
+    external: true

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
 </head>
 <body>
     <div class="container">
-        <h1 id="main-title">TEST</h1>
+        <h1 id="main-title" style="color: blue;">TEST</h1>
         <p>Page de test Hexapilot</p>
     </div>
 </body>


### PR DESCRIPTION
Closes #92

## Résumé
Le projet est un serveur web nginx servi via Docker Compose. Le fichier `public/index.html` est monté en volume read-only dans le conteneur nginx (`./public:/usr/share/nginx/html:ro`). Le `<h1 id="main-title">TEST</h1>` (ligne 36) n'a pas de style inline. Sa couleur est actuellement définie par la règle CSS `h1 { color: #333; }` dans le bloc `<style>` (ligne 24-27). Le ticket demande d'ajouter un attribut `style="color: blue;"` directement sur le tag `<h1>` — ce style inline aura une spécificité

## Modifications
- Étape 1 : Modifier `public/index.html` ligne 36 — ajouter l'attribut `style="color: blue;"` au tag `<h1 id="main-title">`, sans modifier le texte 'TEST' ni aucune autre ligne du fichier
- Étape 2 : Vérifier que seule la ligne 36 a changé (diff minimal) et que le texte du titre reste 'TEST'
- Étape 3 : Valider visuellement via le navigateur sur http://localhost:8080 que le titre s'affiche en bleu

## Critères d'acceptation
- Critère 1 : La ligne 36 de `public/index.html` est exactement `        <h1 id="main-title" style="color: blue;">TEST</h1>`
- Critère 2 : Le texte du titre reste 'TEST' — aucune modification du contenu textuel
- Critère 3 : Aucune autre ligne du fichier `public/index.html` n'est modifiée
- Critère 4 : La page http://localhost:8080 affiche le titre 'TEST' avec la couleur bleue (le style inline `color: blue` écrase la règle CSS `color: #333` du bloc `<style>`)

## Review automatique
- **Statut :** ✅ Approuvé
- **Cycles :** 1
- **Résumé :** La modification est minimale, correcte et conforme au plan. La ligne 36 correspond exactement au critère d'acceptation, le texte 'TEST' est inchangé, et aucune autre ligne n'est touchée. Le style inline `color: blue` a bien une spécificité supérieure à la règle `h1 { color: #333; }` et l'écrasera comme attendu.

---
*PR générée automatiquement par Hexapilot*
