### PR TITLE
fix: Changer la couleur du titre en bleu

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@latest",
+        "--headless"
+      ]
+    }
+  }
+}

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -1,0 +1,17 @@
+# Override Docker Compose pour review via Traefik
+# Généré automatiquement par Hexapilot
+# Le hostname est injecté via la variable d'env REVIEW_HOST
+
+services:
+  app:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${REVIEW_HOST}`)"
+      - "traefik.http.services.${COMPOSE_PROJECT_NAME}.loadbalancer.server.port=80"
+    networks:
+      - default
+      - traefik_network
+
+networks:
+  traefik_network:
+    external: true

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
 </head>
 <body>
     <div class="container">
-        <h1 id="main-title">TEST</h1>
+        <h1 id="main-title" style="color: blue;">TEST</h1>
         <p>Page de test Hexapilot</p>
     </div>
 </body>


### PR DESCRIPTION
Closes #94

## Résumé
Le projet est un serveur nginx minimal (docker-compose.yml) qui sert le dossier ./public en volume read-only sur le port 8080. Le fichier public/index.html contient un <h1 id="main-title">TEST</h1> dont la couleur est actuellement définie à #333 via une règle CSS dans le bloc <style> de la page (ligne 25). Le ticket demande d'ajouter un attribut inline style="color: blue;" directement sur la balise h1, ce qui prendra la priorité sur la règle CSS existante (les styles inline ont une spécificité p

## Modifications
- Étape 1 : Ouvrir public/index.html et localiser la ligne 36 : <h1 id="main-title">TEST</h1>
- Étape 2 : Ajouter l'attribut style="color: blue;" sur cette balise pour obtenir : <h1 id="main-title" style="color: blue;">TEST</h1>
- Étape 3 : Ne modifier aucune autre partie du fichier — ni le texte 'TEST', ni les styles CSS existants dans le <style>, ni aucun autre élément

## Critères d'acceptation
- Critère 1 : La balise <h1 id="main-title"> dans public/index.html possède exactement l'attribut style="color: blue;"
- Critère 2 : Le texte du titre reste inchangé ('TEST')
- Critère 3 : Aucun autre contenu du fichier public/index.html n'est modifié
- Critère 4 : La page affichée sur http://localhost:8080 rend le titre en bleu (le style inline color: blue; écrase la règle CSS h1 { color: #333; } du bloc <style>)

## Review automatique
- **Statut :** ✅ Approuvé
- **Cycles :** 1
- **Résumé :** Le diff implémente exactement ce que le plan demande : ajout de style="color: blue;" sur la balise h1, sans toucher au texte ni au reste du fichier. Tous les critères d'acceptation sont satisfaits. Aucun problème de sécurité, de logique ou de régression identifié.

---
*PR générée automatiquement par Hexapilot*
