### PR TITLE
fix: Changer la couleur du titre en bleu

### DIFF
--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@latest",
+        "--headless"
+      ]
+    }
+  }
+}

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -1,0 +1,17 @@
+# Override Docker Compose pour review via Traefik
+# Généré automatiquement par Hexapilot
+# Le hostname est injecté via la variable d'env REVIEW_HOST
+
+services:
+  app:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${REVIEW_HOST}`)"
+      - "traefik.http.services.${COMPOSE_PROJECT_NAME}.loadbalancer.server.port=80"
+    networks:
+      - default
+      - traefik_network
+
+networks:
+  traefik_network:
+    external: true

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
 </head>
 <body>
     <div class="container">
-        <h1 id="main-title">TEST</h1>
+        <h1 id="main-title" style="color: blue;">TEST</h1>
         <p>Page de test Hexapilot</p>
     </div>
 </body>


### PR DESCRIPTION
Closes #96

## Résumé
Le fichier public/index.html contient un <h1 id="main-title">TEST</h1> à la ligne 36. Actuellement, la couleur du h1 est définie via la règle CSS globale `h1 { color: #333; }` dans le bloc <style> (lignes 24-27). Le ticket demande d'ajouter un attribut inline `style="color: blue;"` directement sur la balise <h1>, ce qui prendra la priorité sur la règle CSS existante (spécificité plus élevée). Le changement est minimal et ciblé : une seule ligne à modifier, sans toucher au texte 'TEST' ni à aucun

## Modifications
- Étape 1 : Ouvrir public/index.html et localiser la ligne 36 contenant <h1 id="main-title">TEST</h1>
- Étape 2 : Ajouter l'attribut style="color: blue;" à la balise <h1>, donnant <h1 id="main-title" style="color: blue;">TEST</h1>
- Étape 3 : Vérifier que le texte 'TEST' et l'id 'main-title' restent inchangés, et qu'aucun autre élément du fichier n'a été modifié

## Critères d'acceptation
- Critère 1 : La balise <h1 id="main-title"> dans public/index.html possède l'attribut style="color: blue;"
- Critère 2 : Le texte du titre reste 'TEST' (inchangé)
- Critère 3 : La page affichée sur http://localhost:8080 rend le titre en bleu (la couleur inline override la règle CSS h1 { color: #333; })
- Critère 4 : Aucune autre modification dans le fichier (ni dans le CSS, ni dans les autres éléments HTML)

## Review automatique
- **Statut :** ✅ Approuvé
- **Cycles :** 1
- **Résumé :** Le changement est minimal, ciblé et correct. L'attribut style="color: blue;" est bien présent sur la balise <h1 id="main-title">, le texte 'TEST' est inchangé, et la spécificité inline (1000) override bien la règle CSS globale h1 { color: #333; } (spécificité 1). Aucune autre ligne n'est modifiée dans le fichier.

---
*PR générée automatiquement par Hexapilot*
