### PR TITLE
fix: changer la couleur du titre en bleu (issue #98)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.playwright-mcp/

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,12 @@
+{
+  "mcpServers": {
+    "chrome-devtools": {
+      "command": "npx",
+      "args": [
+        "-y",
+        "chrome-devtools-mcp@latest",
+        "--headless"
+      ]
+    }
+  }
+}

--- a/docker-compose.review.yml
+++ b/docker-compose.review.yml
@@ -1,0 +1,17 @@
+# Override Docker Compose pour review via Traefik
+# Généré automatiquement par Hexapilot
+# Le hostname est injecté via la variable d'env REVIEW_HOST
+
+services:
+  app:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.${COMPOSE_PROJECT_NAME}.rule=Host(`${REVIEW_HOST}`)"
+      - "traefik.http.services.${COMPOSE_PROJECT_NAME}.loadbalancer.server.port=80"
+    networks:
+      - default
+      - traefik_network
+
+networks:
+  traefik_network:
+    external: true

--- a/public/index.html
+++ b/public/index.html
@@ -33,7 +33,7 @@
 </head>
 <body>
     <div class="container">
-        <h1 id="main-title">TEST</h1>
+        <h1 id="main-title" style="color: blue;">TEST</h1>
         <p>Page de test Hexapilot</p>
     </div>
 </body>


### PR DESCRIPTION
## Summary

- Ajoute `style="color: blue;"` directement sur le `<h1 id="main-title">` pour surcharger la règle CSS `h1 { color: #333; }` via la priorité des styles inline
- Ajoute `.gitignore` avec `.playwright-mcp/` pour éviter que les artefacts temporaires de Playwright ne soient accidentellement commités

## Test plan

- [ ] Vérifier que `<h1 id="main-title">` possède l'attribut `style="color: blue;"`
- [ ] Vérifier que le titre 'TEST' s'affiche en bleu sur http://localhost:8080
- [ ] Vérifier que le texte du titre reste 'TEST' et que la structure HTML est inchangée
- [ ] Vérifier que les fichiers `.playwright-mcp/` ne sont plus trackés par git

🤖 Generated with [Claude Code](https://claude.com/claude-code)